### PR TITLE
Update color average on click

### DIFF
--- a/src/views/Stats/ColorGridWidget.vue
+++ b/src/views/Stats/ColorGridWidget.vue
@@ -1,11 +1,17 @@
 <template>
   <section class="col-12 pt-3 shadow bg-white rounded">
     <h4>Color Grid</h4>
+    <p><i>
+      <strong>Pro tip:</strong>
+      Click on a color to see how average have been changing over time ;)
+    </i></p>
     <div class="row">
       <div class="color-tile"
-        v-for="color in uniqueColors"
+        v-for="(color, index) in uniqueColors"
         :key="color"
-        :style="{ backgroundColor: color }"></div>
+        :style="{ backgroundColor: color }"
+        :class="{ 'selected': (index === selected), 'off': isOff(index) } "
+        @click="updateAvg(index)"></div>
     </div>
   </section>
 </template>
@@ -19,17 +25,44 @@ export default {
       required: true
     }
   },
-  data: () => ({ uniqueColors: undefined }),
+  data: () => ({
+    uniqueColors: undefined,
+    selected: -1
+  }),
   mounted () {
     this.uniqueColors = new Set(this.colors)
+  },
+  methods: {
+    updateAvg (index) {
+      let newColors
+      if (index === this.selected) {
+        this.selected = -1
+        newColors = this.colors
+      } else {
+        this.selected = index
+        newColors = this.colors.slice(0, index + 1)
+      }
+
+      this.$emit('new-average', newColors)
+    },
+    isOff (index) {
+      return (this.selected !== -1 && index > this.selected)
+    }
   }
 }
 </script>
 
 <style lang="stylus">
   .color-tile
+    cursor pointer
     height 1em
     width 1em
     min-height 0.1em
     border solid 1px white
+
+  .selected
+    border 1px solid #000
+
+  .off
+    opacity .3
 </style>

--- a/src/views/Stats/Index.vue
+++ b/src/views/Stats/Index.vue
@@ -37,7 +37,6 @@ export default {
   },
   methods: {
     async getRGBAverage (hexColors) {
-      console.log('lololo')
       const colors = hexColors.map(c => c.replace(/#/g, ''))
       const rgbValue = await this.colorHelper.getRGBAverageFromHex(colors)
       const jsonColor = await this.colorHelper.getJsonColor(rgbValue, 'rgb')

--- a/src/views/Stats/Index.vue
+++ b/src/views/Stats/Index.vue
@@ -4,7 +4,7 @@
     <section class="row" v-if="loaded">
       <StatsWidget class="mr-2" title="Contributors" :value="contributorsCount" />
       <ColorWidget class="ml-2" title="Average Color" :value="averageColor" />
-      <ColorGridWidget class="mt-4" :colors="colors" />
+      <ColorGridWidget class="mt-4" :colors="colors" @new-average="updateAverage" />
     </section>
     <Loader v-else />
   </div>
@@ -33,16 +33,20 @@ export default {
 
   }),
   async mounted () {
-    this.averageColor = await this.getRGBAverage()
-    this.loaded = true
+    this.loaded = await this.updateAverage(this.colors)
   },
   methods: {
-    async getRGBAverage () {
-      const colors = this.colors.map(c => c.replace(/#/g, ''))
+    async getRGBAverage (hexColors) {
+      console.log('lololo')
+      const colors = hexColors.map(c => c.replace(/#/g, ''))
       const rgbValue = await this.colorHelper.getRGBAverageFromHex(colors)
       const jsonColor = await this.colorHelper.getJsonColor(rgbValue, 'rgb')
 
       return jsonColor.hex.value
+    },
+    async updateAverage (colors) {
+      this.averageColor = await this.getRGBAverage(colors)
+      return true
     }
   },
   computed: {


### PR DESCRIPTION
## What does this do?
Update the color average by clicking on any color in the Color Grid

## How is the made?
Clicking any color in the color grid, a `new-average` event will be fired, with the array of colors from the beginning to the selected one. Stats' view will receive this event, and fire the existing average function.

The color average function (`getRGBAverage`) have been modified In order to reuse it, so color array has been passed as a param. Also, the `mounted` function has been modified to use the same `updateAverage` function.

## Why this is added?
Because this PR closes #45 