### PR TITLE
Fix: parrot size on iOS devices

### DIFF
--- a/src/views/About/Index.vue
+++ b/src/views/About/Index.vue
@@ -17,12 +17,12 @@
       </p>
 
       <div class="mt-5 d-flex justify-content-between">
-        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px">
-        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px">
-        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px">
-        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px">
-        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px">
-        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px">
+        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
+        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
+        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
+        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
+        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
+        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">        
       </div>
 
       <div class="text-center">
@@ -31,12 +31,12 @@
       </div>
 
       <div class="d-flex justify-content-between">
-        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px">
-        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px">
-        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px">
-        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px">
-        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px">
-        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px">
+        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
+        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
+        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
+        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
+        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
+        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
       </div>
 
       <hr class="my-5">

--- a/src/views/About/Index.vue
+++ b/src/views/About/Index.vue
@@ -22,7 +22,7 @@
         <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
         <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
         <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
-        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">        
+        <img src="https://cultofthepartyparrot.com/parrots/hd/twinsparrot.gif" alt="parrot-gif" width="25px" height="25px">
       </div>
 
       <div class="text-center">


### PR DESCRIPTION
This happens in Safari

<img width="429" alt="Captura de pantalla 2019-10-06 a las 9 02 42" src="https://user-images.githubusercontent.com/47319388/66265550-e3c97280-e818-11e9-9a97-42c41d10a087.png">
