### PR TITLE
Change location of Twitter share button to the bottom

### DIFF
--- a/src/views/Generate/Index.vue
+++ b/src/views/Generate/Index.vue
@@ -3,7 +3,6 @@
     <header class="text-center mb-5">
       <h2> Generate JSON </h2>
       <p class="lead text-muted">Fill the form in to generate your JSON. Ready to copy & paste!</p>
-      <ShareTwitterBtn/>
     </header>
 
     <form @submit.prevent="generateJson">
@@ -55,6 +54,7 @@
     <div class="result bg-light p-3 mb-2 rounded">
       <pre v-if="showCopyModel" class="mb-0" >{{copyModel}}</pre>
     </div>
+    <ShareTwitterBtn/>
   </div>
 </template>
 


### PR DESCRIPTION
This is a little request #9 that @baumannzone asked. 

I couldn't change the text of the button because Twitter doesn't support it (the way of doing it can be a little bit hackish). 

If you think that the button is okay the way it is, ignore this Pull Request.